### PR TITLE
Constraint: Constrain input to domain

### DIFF
--- a/constraint/README.md
+++ b/constraint/README.md
@@ -10,7 +10,7 @@ Each expression lives in a Markdown file, which contains a general description o
 
 See the list below for shared expressions.
 
-- [Constrain to domain code](./contrainToDomainCode.md)
+- [Constrain to domain code](./constrainToDomainCode.md)
 
 *There aren't any expression templates or functions shared for this profile.*
 

--- a/constraint/README.md
+++ b/constraint/README.md
@@ -10,6 +10,8 @@ Each expression lives in a Markdown file, which contains a general description o
 
 See the list below for shared expressions.
 
+- [Constrain to domain code](./contrainToDomainCode.md)
+
 *There aren't any expression templates or functions shared for this profile.*
 
 ## Resources

--- a/constraint/constrainToDomainCode.md
+++ b/constraint/constrainToDomainCode.md
@@ -28,7 +28,7 @@ if (!haskey($feature, field) || isempty($feature[field])) {
     return true;
 }
 
-return iif (isempty(domainname($feature, 'field, $feature[field])), {
+return iif (isempty(domainname($feature, field, $feature[field])), {
     'errorMessage': 'Value does not fall within the allowable domain values. Input: ' + $feature[field]
 }, true);
 ```

--- a/constraint/constrainToDomainCode.md
+++ b/constraint/constrainToDomainCode.md
@@ -1,0 +1,34 @@
+# Constrain to Domain Code
+
+This expression constrains new input values to values within the domain applied to the field.
+
+## Use cases
+
+As you may or may not know, it was a mistake for esri to allow values to be stored into a field managed by a domain that are outside of the domain values using normal esri editing tools etc. This constraint aims to fix that.
+
+## Workflow
+
+Copy and paste the expression found in the expression template below to the Arcade editor in ArcGIS Online, the relevant location in ArcGIS Pro, or the relevant location in a custom app.
+
+To configure the script to your layer, edit the first line to specify the field you would like to use instead of the example layer. 
+
+```js
+var field = 'field_with_domain';
+```
+
+## Expression Template
+
+This Arcade expression will not allow a value to be entered into a field that is not a part of the domain applied to the field.
+
+```js
+// Refer to the name of the field you would like to protect.
+var field = 'field_with_domain';
+
+if (!haskey($feature, field) || isempty($feature[field])) {
+    return true;
+}
+
+return iif (isempty(domainname($feature, 'field, $feature[field])), {
+    'errorMessage': 'Value does not fall within the allowable domain values. Input: ' + $feature[field]
+}, true);
+```

--- a/constraint/constrainToDomainCode.md
+++ b/constraint/constrainToDomainCode.md
@@ -4,7 +4,7 @@ This expression constrains new input values to values within the domain applied 
 
 ## Use cases
 
-As you may or may not know, it was a mistake for esri to allow values to be stored into a field managed by a domain that are outside of the domain values using normal esri editing tools etc. This constraint aims to fix that.
+As you may or may not know, esri allows values to be stored in a field managed by a domain that are outside of the domain values. You are able to do this using normal esri editing tools etc. This constraint aims to remove this loophole.
 
 ## Workflow
 


### PR DESCRIPTION
🚀🚀 

I should also note that with python and string formatting, you can make this rule very generic...


```py
constain_to_domain = '''if (!haskey($feature, '{0}') || isempty($feature.{0})) {{
    return true;
}}

return iif (isempty(domainname($feature, '{0}', $feature.{0})), {{
    'errorMessage': 'Value does not fall within the allowable domain values. Input: ' + $feature.{0}
}}, true);'''
```