### PR TITLE
Standardize formatting across examples

### DIFF
--- a/dashboard_data/AggregateByDOW(SerialChart).md
+++ b/dashboard_data/AggregateByDOW(SerialChart).md
@@ -3,8 +3,18 @@
 This expression aggregates data by day of the week using the Arcade Weekday() function. The sample data contains a record of new COVID-19 cases across California recorded by county on a daily basis.   
 
 ```
-// Create a FeatureSet from the Feature Layer containing the COVID-19 case information. 
-var fs = FeatureSetByPortalItem(Portal('https://www.arcgis.com'), '290bfa5c085c4861a85573111f2641ce', 0, ["date", "newcountconfirmed"], false);
+// Create a FeatureSet from the Feature Layer containing the COVID-19 case information.
+var portal = Portal('https://www.arcgis.com/');
+var fs = FeatureSetByPortalItem(
+    portal,
+    '290bfa5c085c4861a85573111f2641ce',
+    0,
+    [
+        'date',
+        'newcountconfirmed'
+    ],
+    false
+);
 
 // Group county level data by date. 
 var fs_gp = GroupBy(fs, ['date'], [{name: 'cases_by_day', expression: 'newcountconfirmed', statistic: 'SUM'}]);
@@ -22,9 +32,9 @@ var index = 0;
 for (var feature in fs_gp) { 
     dowDict.features[index] = { 
         'attributes': { 
-            'dow_num': Weekday(feature["date"]), 
-            'dow': Text(feature["date"], 'dddd'),
-            'newcases': feature["cases_by_day"] 
+            'dow_num': Weekday(feature['date']), 
+            'dow': Text(feature['date'], 'dddd'),
+            'newcases': feature['cases_by_day'] 
         }} 
     index++;} 
 

--- a/dashboard_data/CalculationAcrossFields.md
+++ b/dashboard_data/CalculationAcrossFields.md
@@ -3,7 +3,17 @@
 This expression demostrates how calculations can be performed across multiple fields in a layer. We can calculate Case Fatality Ratio from COVID-19 case information using the metrics of confirmed cases and deaths which are recorded in separate fields of the layer. Using date filters, we will calculate CFR for whole dataset and compare it to CFR from a week ago.
 
 ```
-var fs = FeatureSetByPortalItem(Portal('https://www.arcgis.com'), '290bfa5c085c4861a85573111f2641ce', 0, ["newcountconfirmed", "newcountdeaths"], false)
+var portal = Portal('https://www.arcgis.com');
+var fs = FeatureSetByPortalItem(
+    portal,
+    '290bfa5c085c4861a85573111f2641ce',
+    0,
+    [
+        'newcountconfirmed',
+        'newcountdeaths'
+    ],
+    false
+);
      
 var dt_7 = DateAdd(Date(Max(fs, 'date')), -7, 'days')
 var fs_7 = Filter(fs, 'date < @dt_7')

--- a/dashboard_data/CombineMultipleLayers(SerialChart).md
+++ b/dashboard_data/CombineMultipleLayers(SerialChart).md
@@ -1,78 +1,78 @@
 # Combined Multiple Layers 
 
-This expression combines features from multiple feature layers. Each of the three sample data contains a record of how many vaccinations were allocated by each manufacturer (Moderna, Pfizer, and Janssen).   
+This expression combines features from multiple feature layers. Each of the three sample data contains a record of how many vaccinations were allocated by each manufacturer (Moderna, Pfizer, and Janssen).     
 
 ```
 var portal = Portal('https://www.arcgis.com/');
 // Create a FeatureSet for each manufacturer Feature Layer containing vaccination allocation data. 
 // Group the features by the week of allocation 
 var moderna = GroupBy(
-  FeatureSetByPortalItem(portal,'20a80cd89db74c568db7cc9d2a13dc27',0,['*'],false),
-  ['week_of_allocations'],
-  [
-    { name: 'moderna_1', expression: 'F_1st_dose_allocations', statistic: 'SUM' },
-    { name: 'moderna_2', expression: 'F_2nd_dose_allocations', statistic: 'SUM' },
-  ]
+    FeatureSetByPortalItem(portal,'20a80cd89db74c568db7cc9d2a13dc27',0,['*'],false),
+    ['week_of_allocations'],
+    [
+        { name: 'moderna_1', expression: 'F_1st_dose_allocations', statistic: 'SUM' },
+        { name: 'moderna_2', expression: 'F_2nd_dose_allocations', statistic: 'SUM' },
+    ]
 );
 
 var pfizer = GroupBy(
-  FeatureSetByPortalItem(portal,'45c991b4fd6642be8256a6b55f809311',0,['*'],false),
-  ['week_of_allocations'],
-  [
-    { name: 'pfizer_1', expression: 'F_1st_dose_allocations', statistic: 'SUM' },
-    { name: 'pfizer_2', expression: 'F_2nd_dose_allocations', statistic: 'SUM' },
-  ]
+    FeatureSetByPortalItem(portal,'45c991b4fd6642be8256a6b55f809311',0,['*'],false),
+    ['week_of_allocations'],
+    [
+        { name: 'pfizer_1', expression: 'F_1st_dose_allocations', statistic: 'SUM' },
+        { name: 'pfizer_2', expression: 'F_2nd_dose_allocations', statistic: 'SUM' },
+    ]
 );
 
 var janssen = GroupBy(
-  FeatureSetByPortalItem(portal,'d6bf72497e7e4bc69ef9c468e362ca3b',0,['*'],false),
-  ['week_of_allocations'],
-  [{ name: 'janssen', expression: 'F_1st_dose_allocations', statistic: 'SUM' }]
+    FeatureSetByPortalItem(portal,'d6bf72497e7e4bc69ef9c468e362ca3b',0,['*'],false),
+    ['week_of_allocations'],
+    [{ name: 'janssen', expression: 'F_1st_dose_allocations', statistic: 'SUM' }]
 );
 
 var combinedDict = {
-  fields: [
-    { name: 'manufacturer', type: 'esriFieldTypeString' },
-    { name: 'week_of_allocation', type: 'esriFieldTypeString' },
-    { name: 'count_of_doses', type: 'esriFieldTypeInteger' },
-  ],
-  geometryType: '',
-  features: [],
+    fields: [
+        { name: 'manufacturer', type: 'esriFieldTypeString' },
+        { name: 'week_of_allocation', type: 'esriFieldTypeString' },
+        { name: 'count_of_doses', type: 'esriFieldTypeInteger' },
+    ],
+    geometryType: '',
+    features: [],
 };
 
 // Loop through each of the three FeatureSets and store attributes into a combined dictionary.
 var i = 0;
 for (var m in moderna) {
-  combinedDict.features[i] = {
-    attributes: {
-      manufacturer: 'Moderna',
-      week_of_allocation: m['week_of_allocations'],
-      count_of_doses: SUM(m['moderna_1'], m['moderna_2']),
-    },
-  };
-  i++;
+    combinedDict.features[i] = {
+        attributes: {
+            manufacturer: 'Moderna',
+            week_of_allocation: m['week_of_allocations'],
+            count_of_doses: SUM(m['moderna_1'], m['moderna_2']),
+        },
+    };
+    i++;
 }
 
 for (var p in pfizer) {
-  combinedDict.features[i] = {
-    attributes: {
-      manufacturer: 'Pfizer',
-      week_of_allocation: p['week_of_allocations'],
-      count_of_doses: SUM(p['pfizer_1'], p['pfizer_2']),
-    },
-  };
-  i++;
+    combinedDict.features[i] = {
+        attributes: {
+            manufacturer: 'Pfizer',
+            week_of_allocation: p['week_of_allocations'],
+            count_of_doses: SUM(p['pfizer_1'], p['pfizer_2']),
+        },
+    };
+    i++;
 }
 
 for (var j in janssen) {
-  combinedDict.features[i] = {
-    attributes: {
-      manufacturer: 'Janssen',
-      week_of_allocation: j['week_of_allocations'],
-      count_of_doses: j['janssen'],
-    },
-  };
-  i++;
+    combinedDict.features[i] = {
+        attributes: {
+            manufacturer: 'Janssen',
+            week_of_allocation: j['week_of_allocations'],
+            count_of_doses: j['janssen'],
+        },
+    };
+    i++;
 }
 
 // Return dictionary cast as a feature set 

--- a/dashboard_data/CombineMultipleLayers(SerialChart).md
+++ b/dashboard_data/CombineMultipleLayers(SerialChart).md
@@ -3,40 +3,40 @@
 This expression combines features from multiple feature layers. Each of the three sample data contains a record of how many vaccinations were allocated by each manufacturer (Moderna, Pfizer, and Janssen).   
 
 ```
-var portal = Portal("https://www.arcgis.com/");
+var portal = Portal('https://www.arcgis.com/');
 // Create a FeatureSet for each manufacturer Feature Layer containing vaccination allocation data. 
 // Group the features by the week of allocation 
 var moderna = GroupBy(
-  FeatureSetByPortalItem(portal,"20a80cd89db74c568db7cc9d2a13dc27",0,["*"],false),
-  ["week_of_allocations"],
+  FeatureSetByPortalItem(portal,'20a80cd89db74c568db7cc9d2a13dc27',0,['*'],false),
+  ['week_of_allocations'],
   [
-    { name: "moderna_1", expression: "F_1st_dose_allocations", statistic: "SUM" },
-    { name: "moderna_2", expression: "	F_2nd_dose_allocations", statistic: "SUM" },
+    { name: 'moderna_1', expression: 'F_1st_dose_allocations', statistic: 'SUM' },
+    { name: 'moderna_2', expression: 'F_2nd_dose_allocations', statistic: 'SUM' },
   ]
 );
 
 var pfizer = GroupBy(
-  FeatureSetByPortalItem(portal,"45c991b4fd6642be8256a6b55f809311",0,["*"],false),
-  ["week_of_allocations"],
+  FeatureSetByPortalItem(portal,'45c991b4fd6642be8256a6b55f809311',0,['*'],false),
+  ['week_of_allocations'],
   [
-    { name: "pfizer_1", expression: "F_1st_dose_allocations", statistic: "SUM" },
-    { name: "pfizer_2", expression: "	F_2nd_dose_allocations", statistic: "SUM" },
+    { name: 'pfizer_1', expression: 'F_1st_dose_allocations', statistic: 'SUM' },
+    { name: 'pfizer_2', expression: 'F_2nd_dose_allocations', statistic: 'SUM' },
   ]
 );
 
 var janssen = GroupBy(
-  FeatureSetByPortalItem(portal,"d6bf72497e7e4bc69ef9c468e362ca3b",0,["*"],false),
-  ["week_of_allocations"],
-  [{ name: "janssen", expression: "F_1st_dose_allocations", statistic: "SUM" }]
+  FeatureSetByPortalItem(portal,'d6bf72497e7e4bc69ef9c468e362ca3b',0,['*'],false),
+  ['week_of_allocations'],
+  [{ name: 'janssen', expression: 'F_1st_dose_allocations', statistic: 'SUM' }]
 );
 
 var combinedDict = {
   fields: [
-    { name: "manufacturer", type: "esriFieldTypeString" },
-    { name: "week_of_allocation", type: "esriFieldTypeString" },
-    { name: "count_of_doses", type: "esriFieldTypeInteger" },
+    { name: 'manufacturer', type: 'esriFieldTypeString' },
+    { name: 'week_of_allocation', type: 'esriFieldTypeString' },
+    { name: 'count_of_doses', type: 'esriFieldTypeInteger' },
   ],
-  geometryType: "",
+  geometryType: '',
   features: [],
 };
 
@@ -45,9 +45,9 @@ var i = 0;
 for (var m in moderna) {
   combinedDict.features[i] = {
     attributes: {
-      manufacturer: "Moderna",
-      week_of_allocation: m["week_of_allocations"],
-      count_of_doses: SUM(m["moderna_1"], m["moderna_2"]),
+      manufacturer: 'Moderna',
+      week_of_allocation: m['week_of_allocations'],
+      count_of_doses: SUM(m['moderna_1'], m['moderna_2']),
     },
   };
   i++;
@@ -56,9 +56,9 @@ for (var m in moderna) {
 for (var p in pfizer) {
   combinedDict.features[i] = {
     attributes: {
-      manufacturer: "Pfizer",
-      week_of_allocation: p["week_of_allocations"],
-      count_of_doses: SUM(p["pfizer_1"], p["pfizer_2"]),
+      manufacturer: 'Pfizer',
+      week_of_allocation: p['week_of_allocations'],
+      count_of_doses: SUM(p['pfizer_1'], p['pfizer_2']),
     },
   };
   i++;
@@ -67,9 +67,9 @@ for (var p in pfizer) {
 for (var j in janssen) {
   combinedDict.features[i] = {
     attributes: {
-      manufacturer: "Janssen",
-      week_of_allocation: j["week_of_allocations"],
-      count_of_doses: j["janssen"],
+      manufacturer: 'Janssen',
+      week_of_allocation: j['week_of_allocations'],
+      count_of_doses: j['janssen'],
     },
   };
   i++;

--- a/dashboard_data/GroupByMultiStats(List).md
+++ b/dashboard_data/GroupByMultiStats(List).md
@@ -3,7 +3,19 @@
 This expression calculates mutliple statistic values using the GroupBy() function. The featureset can be used to enhance the List element which supports feature-based visualization. 
 
 ```
-var fs = FeatureSetByPortalItem(Portal('https://arcgis.com/'), '164373608f1241e78c66f8f4b9822866', 0, ['COUNTY','STATIONNUM','RAINFALL','ADVISORYDESC'], false);
+var portal = Portal('https://www.arcgis.com/');
+var fs = FeatureSetByPortalItem(
+    portal,
+    '164373608f1241e78c66f8f4b9822866',
+    0,
+    [
+        'COUNTY',
+        'STATIONNUM',
+        'RAINFALL',
+        'ADVISORYDESC'
+    ],
+    false
+);
 
 return GroupBy(fs, ['COUNTY'], 
 [{name: 'total_sites', expression: 'STATIONNUM', statistic: 'COUNT' }, 

--- a/dashboard_data/HavingClause(SerialChart).md
+++ b/dashboard_data/HavingClause(SerialChart).md
@@ -1,7 +1,20 @@
+# HAVING Clause
+
 This data expression can be used to mimic the SQL ```HAVING``` clause which filters on aggregated data. 
 
 ```
-var fs= FeatureSetByPortalItem(Portal('https://www.arcgis.com'),'f8492125f78445b284751ced4e9d6573',0,['Waterbody_Type','Rainfall'],false);
+var portal = Portal('https://www.arcgis.com/');
+var fs = FeatureSetByPortalItem(
+    portal,
+    'f8492125f78445b284751ced4e9d6573',
+    0,
+    [
+        'Waterbody_Type',
+        'Rainfall'
+    ],
+    false
+);
+
 return Filter(OrderBy(GroupBy(fs,['Waterbody_Type'],[{name:'AVG_RF',expression:'Rainfall',statistic:'AVG'}]),'AVG_RF DESC'), 'AVG_RF > 1');
 ```
 

--- a/dashboard_data/MostRecentRecords(IndicatorOrGuage).md
+++ b/dashboard_data/MostRecentRecords(IndicatorOrGuage).md
@@ -3,26 +3,26 @@
 This expression retrieves the most recent feature (or row) from a set of features. The sample data contains COVID-19 vaccination records captured over time on a daily basis.   
 
 ```
-var portal = Portal("https://www.arcgis.com/");
+var portal = Portal('https://www.arcgis.com/');
 var fs = FeatureSetByPortalItem(
   portal,
-  "b2c50a7730a74f8d808262ce0c37ac79",
+  'b2c50a7730a74f8d808262ce0c37ac79',
   0,
   [
-    "date",
-    "location",
-    "total_vaccinations",
-    "people_vaccinated",
-    "people_vaccinated_per_hundred",
-    "people_fully_vaccinated",
-    "people_fully_vaccinated_per_hun",
+    'date',
+    'location',
+    'total_vaccinations',
+    'people_vaccinated',
+    'people_vaccinated_per_hundred',
+    'people_fully_vaccinated',
+    'people_fully_vaccinated_per_hun',
   ],
   false
 );
 
 // Find the most recent date from the date field to filter the FeatureSet for the latest record
-var maxDate = Text(Date(Max(fs,'date')),"YYYY-MM-DD");
-return Filter(fs, "date = @maxDate");
+var maxDate = Text(Date(Max(fs,'date')),'YYYY-MM-DD');
+return Filter(fs, 'date = @maxDate');
 
 ```
 

--- a/dashboard_data/SplitCategories(PieChart).md
+++ b/dashboard_data/SplitCategories(PieChart).md
@@ -2,8 +2,15 @@
 
 This data expression splits a comma separated values in a field into multiple rows of single values. A common use case is data from a Survey123 form with multichoice questions, like in the below example. 
 ```
-// Reference layer using the FeatureSetByPortalItem() method. 
-var fs = FeatureSetByPortalItem(Portal('https://www.arcgis.com'), 'd10b9e8dbd7f4cccbd0a938a06c586e9' , 0, ['Report_road_condition'], false);
+// Reference layer using the FeatureSetByPortalItem() method.
+var portal = Portal('https://www.arcgis.com')
+var fs = FeatureSetByPortalItem(
+    portal,
+    'd10b9e8dbd7f4cccbd0a938a06c586e9',
+    0,
+    ['Report_road_condition'],
+    false
+);
 
 // Empty dictionary to capture each hazard reported as separate rows. 
 var choicesDict = {'fields': [{ 'name': 'split_choices', 'type': 'esriFieldTypeString'}], 


### PR DESCRIPTION
I noticed that across the different examples, formatting was not entirely consistent. This PR simply standardizes of of the formatting issues such as tab size, breaking the `FeatureSetByPortalItem` function across multiple lines, use of single/double quote marks, etc.