### PR TITLE
push directly to dict, no intermediate vars

### DIFF
--- a/dashboard_data/AggregateByDOW(SerialChart).md
+++ b/dashboard_data/AggregateByDOW(SerialChart).md
@@ -1,10 +1,11 @@
-# Aggregate by Day of Week 
+# Aggregate by Day of Week
 
-This expression aggregates data by day of the week using the Arcade Weekday() function. The sample data contains a record of new COVID-19 cases across California recorded by county on a daily basis.   
+This expression aggregates data by day of the week using the Arcade Weekday() function. The sample data contains a record of new COVID-19 cases across California recorded by county on a daily basis.
 
 ```js
 // Create a FeatureSet from the Feature Layer containing the COVID-19 case information.
 var portal = Portal('https://www.arcgis.com/');
+
 var fs = FeatureSetByPortalItem(
     portal,
     '290bfa5c085c4861a85573111f2641ce',
@@ -16,39 +17,49 @@ var fs = FeatureSetByPortalItem(
     false
 );
 
-// Group county level data by date. 
-var fs_gp = GroupBy(fs, ['date'], [{name: 'cases_by_day', expression: 'newcountconfirmed', statistic: 'SUM'}]);
+// Group county level data by date.
+var fs_gp = GroupBy(
+    fs,
+    'date',
+    {name: 'cases_by_day', expression: 'newcountconfirmed', statistic: 'SUM'}
+);
 
-// Create array for holding features, feat object for populating array
-var features = [];
-var feat;
-
-// Populate feature array
-for (var feature in fs_gp) { 
-    feat = { 
-        'attributes': { 
-            'dow_num': Weekday(feature['date']), 
-            'dow': Text(feature['date'], 'dddd'),
-            'newcases': feature['cases_by_day'] 
-        }}
-    Push(features, feat);
+// Create dict to hold output features
+var dowDict = {
+    fields: [
+        {name: 'dow_num', type: 'esriFieldTypeInteger'},
+        {name: 'dow', type: 'esriFieldTypeString'},
+        {name: 'newcases', type: 'esriFieldTypeInteger'}
+    ],
+    geometryType: '',
+    features: []
 };
 
-var dowDict = { 
-  'fields': [{ 'name': 'dow_num', 'type': 'esriFieldTypeInteger'},
-  {'name': 'dow', 'type': 'esriFieldTypeString'}, 
-  {'name': 'newcases', 'type': 'esriFieldTypeInteger'}], 
-  'geometryType': '', 
-  'features': features
-}; 
+// Populate feature array
+for (var feature in fs_gp) {
+    Push(
+        dowDict,
+        {
+            attributes: {
+                dow_num: Weekday(feature['date']),
+                dow: Text(feature['date'], 'dddd'),
+                newcases: feature['cases_by_day']
+            }
+        }
+    )
+};
 
-// Convert dictionary to feature set. 
-var fs_dict = FeatureSet(Text(dowDict)); 
+// Convert dictionary to feature set.
+var fs_dict = FeatureSet(Text(dowDict));
 
 // Return case data by day of week.
-return GroupBy(fs_dict, ['dow_num', 'dow'], [{ name: 'cases_by_dow', expression: 'newcases', statistic: 'SUM'}]); 
+return GroupBy(
+    fs_dict,
+    ['dow_num', 'dow'],
+    {name: 'cases_by_dow', expression: 'newcases', statistic: 'SUM'}
+);
 ```
 
-We can use this expression to create a serial chart that shows the trend in cases reported by day of the week. 
+We can use this expression to create a serial chart that shows the trend in cases reported by day of the week.
 
 ![Serial chart](/dashboard_data/images/DOW.png)

--- a/dashboard_data/CombineMultipleLayers(SerialChart).md
+++ b/dashboard_data/CombineMultipleLayers(SerialChart).md
@@ -4,83 +4,115 @@ This expression combines features from multiple feature layers. Each of the thre
 
 ```js
 var portal = Portal('https://www.arcgis.com/');
+
 // Create a FeatureSet for each manufacturer Feature Layer containing vaccination allocation data. 
 // Group the features by the week of allocation 
 var moderna = GroupBy(
-    FeatureSetByPortalItem(portal,'20a80cd89db74c568db7cc9d2a13dc27',0,['*'],false),
-    ['week_of_allocations'],
+    FeatureSetByPortalItem(
+        portal,
+        '20a80cd89db74c568db7cc9d2a13dc27',
+        0,
+        [
+            'week_of_allocations',
+            'F_1st_dose_allocations',
+            'F_2nd_dose_allocations'
+        ],
+        false
+    ),
+    'week_of_allocations',
     [
-        { name: 'moderna_1', expression: 'F_1st_dose_allocations', statistic: 'SUM' },
-        { name: 'moderna_2', expression: 'F_2nd_dose_allocations', statistic: 'SUM' },
+        {name: 'moderna_1', expression: 'F_1st_dose_allocations', statistic: 'SUM'},
+        {name: 'moderna_2', expression: 'F_2nd_dose_allocations', statistic: 'SUM'}
     ]
 );
 
 var pfizer = GroupBy(
-    FeatureSetByPortalItem(portal,'45c991b4fd6642be8256a6b55f809311',0,['*'],false),
-    ['week_of_allocations'],
+    FeatureSetByPortalItem(
+        portal,
+        '45c991b4fd6642be8256a6b55f809311',
+        0,
+        [
+            'week_of_allocations',
+            'F_1st_dose_allocations',
+            'F_2nd_dose_allocations'
+        ],
+        false
+    ),
+    'week_of_allocations',
     [
-        { name: 'pfizer_1', expression: 'F_1st_dose_allocations', statistic: 'SUM' },
-        { name: 'pfizer_2', expression: 'F_2nd_dose_allocations', statistic: 'SUM' },
+        {name: 'pfizer_1', expression: 'F_1st_dose_allocations', statistic: 'SUM'},
+        {name: 'pfizer_2', expression: 'F_2nd_dose_allocations', statistic: 'SUM'}
     ]
 );
 
 var janssen = GroupBy(
-    FeatureSetByPortalItem(portal,'d6bf72497e7e4bc69ef9c468e362ca3b',0,['*'],false),
-    ['week_of_allocations'],
-    [{ name: 'janssen', expression: 'F_1st_dose_allocations', statistic: 'SUM' }]
+    FeatureSetByPortalItem(
+        portal,
+        'd6bf72497e7e4bc69ef9c468e362ca3b',
+        0,
+        [
+            'week_of_allocations',
+            'F_1st_dose_allocations'
+        ],
+        false
+    ),
+    'week_of_allocations',
+    {name: 'janssen', expression: 'F_1st_dose_allocations', statistic: 'SUM'}
 );
 
-// Create empty array for features, feat object to populate array
-var features = [];
-var feat;
-
-// Loop through each of the three FeatureSets and populate feature array.
-for (var m in moderna) {
-    feat = {
-        attributes: {
-            manufacturer: 'Moderna',
-            week_of_allocation: m['week_of_allocations'],
-            count_of_doses: SUM(m['moderna_1'], m['moderna_2']),
-        },
-    };
-    Push(features, feat);
-}
-
-for (var p in pfizer) {
-    feat = {
-        attributes: {
-            manufacturer: 'Pfizer',
-            week_of_allocation: p['week_of_allocations'],
-            count_of_doses: SUM(p['pfizer_1'], p['pfizer_2']),
-        },
-    };
-    Push(features, feat);
-}
-
-for (var j in janssen) {
-    feat = {
-        attributes: {
-            manufacturer: 'Janssen',
-            week_of_allocation: j['week_of_allocations'],
-            count_of_doses: j['janssen'],
-        },
-    };
-    Push(features, feat);
-}
-
+// Create dict to hold output features
 var combinedDict = {
     fields: [
         { name: 'manufacturer', type: 'esriFieldTypeString' },
         { name: 'week_of_allocation', type: 'esriFieldTypeString' },
-        { name: 'count_of_doses', type: 'esriFieldTypeInteger' },
+        { name: 'count_of_doses', type: 'esriFieldTypeInteger' }
     ],
     geometryType: '',
-    features: features,
+    features: []
 };
+
+// Loop through each of the three FeatureSets and populate feature array.
+for (var m in moderna) {
+    Push(
+        combinedDict['features'],
+        {
+            attributes: {
+                manufacturer: 'Moderna',
+                week_of_allocation: m['week_of_allocations'],
+                count_of_doses: SUM(m['moderna_1'], m['moderna_2'])
+            }
+        }
+    )
+}
+
+for (var p in pfizer) {
+    Push(
+        combinedDict['features'],
+        {
+            attributes: {
+                manufacturer: 'Pfizer',
+                week_of_allocation: p['week_of_allocations'],
+                count_of_doses: SUM(p['pfizer_1'], p['pfizer_2'])
+            }
+        }
+    )
+}
+
+for (var j in janssen) {
+    Push(
+        combinedDict['features'],
+        {
+            attributes: {
+                manufacturer: 'Janssen',
+                week_of_allocation: j['week_of_allocations'],
+                count_of_doses: j['janssen']
+            }
+        }
+    )
+}
 
 // Return dictionary cast as a feature set 
 return FeatureSet(Text(combinedDict));
-
 ```
 
 We can use this expression to create a serial chart that shows both the cumulative count of vaccinations allocated each week and how many doses were allocated by each manufacturer. 

--- a/dashboard_data/SpatialAggregation.md
+++ b/dashboard_data/SpatialAggregation.md
@@ -4,6 +4,8 @@ This expression aggregates data from one layer using a spatial relationship with
 
 In this specific example, point features ([Global Power Plants](https://www.arcgis.com/home/item.html?id=848d61af726f40d890219042253bedd7)) are being aggregated by polygons ([Time Zones](https://www.arcgis.com/home/item.html?id=312cebfea2624e108e234220b04460b8)) using the **Contains** function.
 
+Please note: including spatial information can severely impact performance, depending on the size of the layer and the type of operation performed.
+
 ```js
 // Portal
 var portal = Portal('https://www.arcgis.com/');
@@ -13,9 +15,7 @@ var poly_fs = FeatureSetByPortalItem(
     portal,
     '312cebfea2624e108e234220b04460b8',
     0,
-    [
-        'ZONE'
-    ],
+    ['ZONE'],
     true
 );
 
@@ -24,46 +24,40 @@ var pt_fs = FeatureSetByPortalItem(
     portal,
     '848d61af726f40d890219042253bedd7',
     0,
-    [
-        'capacity_mw'
-    ],
+    ['capacity_mw'],
     true
 );
 
-// Create empty feature array and feat object for output
-var features = [];
-var feat;
+// Create dict for output FeatureSet
+var out_dict = {
+    fields: [
+        {name: 'tz', alias: 'Time Zone', type: 'esriFieldTypeString'},
+        {name: 'pt_cnt', alias: 'Number of Power Plants', type: 'esriFieldTypeInteger'}
+    ],
+  geometryType: '',
+  features: []
+};
 
 // Iterate over time zones
 for (var poly in poly_fs) {
-    
+
     // Filter points by polygon
     var pts = Contains(poly, pt_fs);
-    
-    // Create feature with aggregated values
-    feat = { 
-        'attributes': { 
-            'tz': poly['ZONE'], 
-            'pt_cnt': Count(pts)
+
+    // Push feature to dict
+    Push(
+        out_dict['features'],
+        {
+            attributes: {
+                tz: poly['ZONE'],
+                pt_cnt: Count(pts)
+            }
         }
-    };
-    
-    // Push feature into array
-    Push(features, feat);
-};
+    )
+}
 
-// Create dict for output FeatureSet
-var out_dict = { 
-    'fields': [
-        {'name': 'tz', 'alias': 'Time Zone', 'type': 'esriFieldTypeString'},
-        {'name': 'pt_cnt', 'alias': 'Number of Power Plants', 'type': 'esriFieldTypeInteger'}
-    ],
-  'geometryType': '', 
-  'features': features 
-}; 
-
-// Convert dictionary to feature set. 
-return FeatureSet(Text(out_dict)); 
+// Convert dictionary to feature set.
+return FeatureSet(Text(out_dict));
 ```
 
 We can use this expression to create a serial chart or list that shows the number of points per polygon. Simple modifications to this expression can add additional statistics, such as **Sum**, **Average**, and the like.

--- a/dashboard_data/SplitCategories(PieChart).md
+++ b/dashboard_data/SplitCategories(PieChart).md
@@ -1,10 +1,11 @@
 ## Split comma separated values across multiple rows
 
-This data expression splits a comma separated values in a field into multiple rows of single values. A common use case is data from a Survey123 form with multichoice questions, like in the below example. 
+This data expression splits a comma separated values in a field into multiple rows of single values. A common use case is data from a Survey123 form with multichoice questions, like in the below example.
 
 ```js
 // Reference layer using the FeatureSetByPortalItem() method.
 var portal = Portal('https://www.arcgis.com')
+
 var fs = FeatureSetByPortalItem(
     portal,
     'd10b9e8dbd7f4cccbd0a938a06c586e9',
@@ -13,38 +14,44 @@ var fs = FeatureSetByPortalItem(
     false
 );
 
-// Create empty array for features and feat object
-var features = [];
-var feat;
-
-// Split comma separated hazard types and store in dictionary.  
-for (var feature in fs) { 
-    var split_array  =  Split(feature["Report_road_condition"], ',') 
-    var count_arr = Count(split_array) 
-    for(var i = 0; i < count_arr; i++ ){ 
-        feat = {
-            'attributes': {
-                'split_choices': Trim(split_array[i])
-            }
-        Push(features, feat);
-}}} 
-
-// Empty dictionary to capture each hazard reported as separate rows. 
+// Empty dictionary to capture each hazard reported as separate rows.
 var choicesDict = {
-    'fields': [
-        { 'name': 'split_choices', 'type': 'esriFieldTypeString'}], 
-    'geometryType': '',
-    'features': features
-}; 
+    fields: [
+        {name: 'split_choices', type: 'esriFieldTypeString'}
+    ],
+    geometryType: '',
+    features: []
+};
 
-// Convert dictionary to featureSet. 
-var fs_dict = FeatureSet(Text(choicesDict)); 
+// Split comma separated hazard types and store in dictionary.
+for (var feature in fs) {
+    var split_array = Split(feature["Report_road_condition"], ',')
+    var count_arr = Count(split_array)
 
-// Return featureset after grouping by hazard types. 
-return GroupBy(fs_dict, ['split_choices'], 
-       [{ name: 'split_count', expression: 'split_choices', statistic: 'COUNT' }]);  
+    // Push features to dict
+    for (var i = 0; i < count_arr; i++) {
+        Push(
+            choicesDict['features'],
+            {
+                attributes: {
+                    split_choices: Trim(split_array[i])
+                }
+            }
+        )
+    }
+}
+
+// Convert dictionary to featureSet.
+var fs_dict = FeatureSet(Text(choicesDict));
+
+// Return featureset after grouping by hazard types.
+return GroupBy(
+    fs_dict,
+    'split_choices',
+    {name: 'split_count', expression: 'split_choices', statistic: 'COUNT'}
+);
 ```
 
-By restructuring data, we are able to build a more effective pie chart. The below image shows two pie charts for the same underlying dataset. The chart on the left visualizes the raw data. The chart on the right is driven by the enhanced dataset generated this data expression.  
+By restructuring data, we are able to build a more effective pie chart. The below image shows two pie charts for the same underlying dataset. The chart on the left visualizes the raw data. The chart on the right is driven by the enhanced dataset generated this data expression.
 
 ![](/dashboard_data/images/SplitCategories(PieChart).png)


### PR DESCRIPTION
It's been a while since I contributed the addition of the  `Push` function to some of the Data Expressions. I've been using versions of these expressions extensively since, and I've thought better of the creation of intermediate vars `feat` and `features`.

Instead, why not just create the output dict first (like before), but use the function directly with the dict?

`Push(outDict['features'], {attributes:{someatt: 'someval'}})`

I also did some minor formatting tweaks and cleaned up some unnecessary whitespace.