### PR TITLE
Dashboard data update for feature sets accepting dictionaries

### DIFF
--- a/dashboard_data/AggregateByDOW(SerialChart).md
+++ b/dashboard_data/AggregateByDOW(SerialChart).md
@@ -2,6 +2,8 @@
 
 This expression aggregates data by day of the week using the Arcade Weekday() function. The sample data contains a record of new COVID-19 cases across California recorded by county on a daily basis.   
 
+_Note for Enterprise users: Prior to Enterprise 11.2, the FeatureSet() function does not accept dictionaries. You must wrap the dictionary with a Text() function: FeatureSet(Text(dict)). Additionally, dates need to be in EPOCH and can be converted by wrapping them with the Number() function: Number(Now()). For more information see https://community.esri.com/t5/arcgis-dashboards-blog/dashboard-data-expressions-what-has-changed-june/bc-p/1299698_
+
 ```js
 // Create a FeatureSet from the Feature Layer containing the COVID-19 case information.
 var portal = Portal('https://www.arcgis.com/');
@@ -43,7 +45,7 @@ var dowDict = {
 }; 
 
 // Convert dictionary to feature set. 
-var fs_dict = FeatureSet(Text(dowDict)); 
+var fs_dict = FeatureSet(dowDict); 
 
 // Return case data by day of week.
 return GroupBy(fs_dict, ['dow_num', 'dow'], [{ name: 'cases_by_dow', expression: 'newcases', statistic: 'SUM'}]); 

--- a/dashboard_data/CalculationAcrossFields.md
+++ b/dashboard_data/CalculationAcrossFields.md
@@ -2,6 +2,8 @@
 
 This expression demostrates how calculations can be performed across multiple fields in a layer. We can calculate Case Fatality Ratio from COVID-19 case information using the metrics of confirmed cases and deaths which are recorded in separate fields of the layer. Using date filters, we will calculate CFR for whole dataset and compare it to CFR from a week ago.
 
+_Note for Enterprise users: Prior to Enterprise 11.2, the FeatureSet() function does not accept dictionaries. You must wrap the dictionary with a Text() function: FeatureSet(Text(dict)). Additionally, dates need to be in EPOCH and can be converted by wrapping them with the Number() function: Number(Now()). For more information see https://community.esri.com/t5/arcgis-dashboards-blog/dashboard-data-expressions-what-has-changed-june/bc-p/1299698_
+
 ```js
 var portal = Portal('https://www.arcgis.com');
 var fs = FeatureSetByPortalItem(
@@ -28,7 +30,7 @@ var ratioDict = {
       'CFR_7': Round((SUM(fs_7,'newcountdeaths')/SUM(fs_7,'newcountconfirmed'))*100,2)
      }}]}; 
 
-return FeatureSet(Text(ratioDict)); 
+return FeatureSet(ratioDict); 
 ```
 
 The FeatureSet returns Case Fatality Ratio as a percentage which can visualized in an Indicator element. 

--- a/dashboard_data/CombineMultipleLayers(SerialChart).md
+++ b/dashboard_data/CombineMultipleLayers(SerialChart).md
@@ -2,6 +2,8 @@
 
 This expression combines features from multiple feature layers. Each of the three sample data contains a record of how many vaccinations were allocated by each manufacturer (Moderna, Pfizer, and Janssen).     
 
+_Note for Enterprise users: Prior to Enterprise 11.2, the FeatureSet() function does not accept dictionaries. You must wrap the dictionary with a Text() function: FeatureSet(Text(dict)). Additionally, dates need to be in EPOCH and can be converted by wrapping them with the Number() function: Number(Now()). For more information see https://community.esri.com/t5/arcgis-dashboards-blog/dashboard-data-expressions-what-has-changed-june/bc-p/1299698_
+
 ```js
 var portal = Portal('https://www.arcgis.com/');
 // Create a FeatureSet for each manufacturer Feature Layer containing vaccination allocation data. 
@@ -79,7 +81,7 @@ var combinedDict = {
 };
 
 // Return dictionary cast as a feature set 
-return FeatureSet(Text(combinedDict));
+return FeatureSet(combinedDict);
 
 ```
 

--- a/dashboard_data/GroupByMultiStats(List).md
+++ b/dashboard_data/GroupByMultiStats(List).md
@@ -2,11 +2,13 @@
 
 This expression calculates mutliple statistic values using the GroupBy() function. The featureset can be used to enhance the List element which supports feature-based visualization. 
 
+_Note for Enterprise users: Prior to Enterprise 11.2, the FeatureSet() function does not accept dictionaries. You must wrap the dictionary with a Text() function: FeatureSet(Text(dict)). Additionally, dates need to be in EPOCH and can be converted by wrapping them with the Number() function: Number(Now()). For more information see https://community.esri.com/t5/arcgis-dashboards-blog/dashboard-data-expressions-what-has-changed-june/bc-p/1299698_
+
 ```js
 var portal = Portal('https://www.arcgis.com/');
 var fs = FeatureSetByPortalItem(
     portal,
-    '164373608f1241e78c66f8f4b9822866',
+    'ac53e31738bf488d9f3c0534c7635a91',
     0,
     [
         'COUNTY',

--- a/dashboard_data/JoinLayerFieldsToTable.md
+++ b/dashboard_data/JoinLayerFieldsToTable.md
@@ -5,6 +5,8 @@ https://doc.arcgis.com/en/arcgis-online/analyze/join-features.htm
 
 In cases where the dynamic join isn't possible (i.e. you are not the owner of the layers, you're pulling data from Portal into ArcGIS Online, etc) this workflow could be used to add attributes from the source layer to the target.
 
+_Note for Enterprise users: Prior to Enterprise 11.2, the FeatureSet() function does not accept dictionaries. You must wrap the dictionary with a Text() function: FeatureSet(Text(dict)). Additionally, dates need to be in EPOCH and can be converted by wrapping them with the Number() function: Number(Now()). For more information see https://community.esri.com/t5/arcgis-dashboards-blog/dashboard-data-expressions-what-has-changed-june/bc-p/1299698_
+
 ## Example Expression
 
 ```js
@@ -60,7 +62,7 @@ var joinedDict = {
 };
 
 // Return dictionary cast as a feature set 
-return FeatureSet(Text(joinedDict));
+return FeatureSet(joinedDict);
 ```
 
 Bringing additional attributes into our main layer by a shared ID allows us to combine data we would otherwise not be able to, as in the following chart. Note that the `DPS_Region` field comes from the polygon layer, while the `ModelID` and `AddressCount` fields come from the tabular layer.

--- a/dashboard_data/SpatialAggregation.md
+++ b/dashboard_data/SpatialAggregation.md
@@ -65,7 +65,7 @@ var out_dict = {
 }; 
 
 // Convert dictionary to feature set. 
-return FeatureSet(out_dicear); 
+return FeatureSet(out_dict); 
 ```
 
 We can use this expression to create a serial chart or list that shows the number of points per polygon. Simple modifications to this expression can add additional statistics, such as **Sum**, **Average**, and the like.

--- a/dashboard_data/SpatialAggregation.md
+++ b/dashboard_data/SpatialAggregation.md
@@ -4,6 +4,8 @@ This expression aggregates data from one layer using a spatial relationship with
 
 In this specific example, point features ([Global Power Plants](https://www.arcgis.com/home/item.html?id=848d61af726f40d890219042253bedd7)) are being aggregated by polygons ([Time Zones](https://www.arcgis.com/home/item.html?id=312cebfea2624e108e234220b04460b8)) using the **Contains** function.
 
+_Note for Enterprise users: Prior to Enterprise 11.2, the FeatureSet() function does not accept dictionaries. You must wrap the dictionary with a Text() function: FeatureSet(Text(dict)). Additionally, dates need to be in EPOCH and can be converted by wrapping them with the Number() function: Number(Now()). For more information see https://community.esri.com/t5/arcgis-dashboards-blog/dashboard-data-expressions-what-has-changed-june/bc-p/1299698_
+
 ```js
 // Portal
 var portal = Portal('https://www.arcgis.com/');
@@ -63,7 +65,7 @@ var out_dict = {
 }; 
 
 // Convert dictionary to feature set. 
-return FeatureSet(Text(out_dict)); 
+return FeatureSet(out_dicear); 
 ```
 
 We can use this expression to create a serial chart or list that shows the number of points per polygon. Simple modifications to this expression can add additional statistics, such as **Sum**, **Average**, and the like.

--- a/dashboard_data/SplitCategories(PieChart).md
+++ b/dashboard_data/SplitCategories(PieChart).md
@@ -2,6 +2,8 @@
 
 This data expression splits a comma separated values in a field into multiple rows of single values. A common use case is data from a Survey123 form with multichoice questions, like in the below example. 
 
+_Note for Enterprise users: Prior to Enterprise 11.2, the FeatureSet() function does not accept dictionaries. You must wrap the dictionary with a Text() function: FeatureSet(Text(dict)). Additionally, dates need to be in EPOCH and can be converted by wrapping them with the Number() function: Number(Now()). For more information see https://community.esri.com/t5/arcgis-dashboards-blog/dashboard-data-expressions-what-has-changed-june/bc-p/1299698_
+
 ```js
 // Reference layer using the FeatureSetByPortalItem() method.
 var portal = Portal('https://www.arcgis.com')
@@ -39,7 +41,7 @@ var choicesDict = {
 }; 
 
 // Convert dictionary to featureSet. 
-var fs_dict = FeatureSet(Text(choicesDict)); 
+var fs_dict = FeatureSet(choicesDict); 
 
 // Return featureset after grouping by hazard types. 
 return GroupBy(fs_dict, ['split_choices'], 

--- a/dashboard_data/WorkforceWorkerNameAssignmentType.md
+++ b/dashboard_data/WorkforceWorkerNameAssignmentType.md
@@ -51,12 +51,7 @@ var returnFS = {
 for (var a in assigned){
     var t = {}
     for (var f in a){
-        if (TypeOf(a[f]) == 'Date'){
-            // Convert date fields to Unix Timestamp
-            t[f] = Number(a[f])
-        } else{
-            t[f] = a[f]
-        }
+        t[f] = a[f]
     }
     var n = getTableValue(workers, a.workerid, 'globalid', 'name')
     t["worker_name"] = n
@@ -65,9 +60,30 @@ for (var a in assigned){
 
     Push(returnFS.features, {'attributes':t})
 }
-return FeatureSet(Text(returnFS))
+return FeatureSet(returnFS)
 ```
 
 The resulting data can be visualized in a serial chart element using the 'Categories from Features' configuration.
 
 ![](/dashboard_data/images/workforce-worker-name-assignment-type.png)
+
+
+_Note for Enterprise users: Prior to Enterprise 11.2, the FeatureSet() function does not accept dictionaries. You must wrap the dictionary with a Text() function: FeatureSet(Text(dict)). Additionally, dates need to be in EPOCH and can be converted by wrapping them with the Number() function: Number(Now()). For more information see https://community.esri.com/t5/arcgis-dashboards-blog/dashboard-data-expressions-what-has-changed-june/bc-p/1299698_
+
+At line 40, when you loop through the assigned you will have to use the following:
+
+```js
+for (var f in a){
+        if (TypeOf(a[f]) == 'Date'){
+            // Convert date fields to Unix Timestamp
+            t[f] = Number(a[f])
+        } else{
+            t[f] = a[f]
+        }
+    }
+```
+
+At line 50, you will have to covert the dictionary to text based JSON:
+```js
+return FeatureSet(Text(returnFS))
+```


### PR DESCRIPTION
With the June release of Arcade and ArcGIS Dashboards, [FeatureSets can now accept dictionaries](https://community.esri.com/t5/arcgis-dashboards-blog/dashboard-data-expressions-what-has-changed-june/bc-p/1299698). Updated the sample dashboard data expressions to pass in the dictionary. Added note for Enterprise users. 